### PR TITLE
`petsctools.init` returns `petsc4py.PETSc`

### DIFF
--- a/petsctools/init.py
+++ b/petsctools/init.py
@@ -36,6 +36,8 @@ def init(argv=None, *, version_spec=""):
         PETSc.Options().getAll()
     )
 
+    return PETSc
+
 
 def check_environment_matches_petsc4py_config():
     import petsc4py


### PR DESCRIPTION
Just a little change, but it makes initialising and importing PETSc into a single step rather than having to call a function before importing a module (which is not very intuitive python).

It replaces this code:
```python
from petsctools import init as petsc_init
petsc_init()
from petsc4py import PETSc
```
with this:
```python
from petsctools import init as petsc_init
PETSc = petsc_init()
```