### PR TITLE
Use proper prefix when checking options_left

### DIFF
--- a/petsctools/options.py
+++ b/petsctools/options.py
@@ -485,11 +485,15 @@ class OptionsManager:
         self._used_options = set()
 
         # Decide whether to warn for unused options
+        options_left = self.options_object.getBool("options_left", False)
         with self.inserted_options():
-            if self.options_object.getBool("options_left", False):
-                weakref.finalize(self, _warn_unused_options,
-                                 self.to_delete, self._used_options,
-                                 options_prefix=self.options_prefix)
+            options_left = self.options_object.getBool(
+                f"{self.options_prefix}options_left", options_left)
+
+        if options_left:
+            weakref.finalize(self, _warn_unused_options,
+                             self.to_delete, self._used_options,
+                             options_prefix=self.options_prefix)
 
     def set_default_parameter(self, key: str, val: Any) -> None:
         """Set a default parameter value.

--- a/petsctools/options.py
+++ b/petsctools/options.py
@@ -487,8 +487,8 @@ class OptionsManager:
         # Decide whether to warn for unused options
         options_left = self.options_object.getBool("options_left", False)
         with self.inserted_options():
-            options_left = self.options_object.getBool(
-                f"{self.options_prefix}options_left", options_left)
+            options_left = options_left or self.options_object.getBool(
+                f"{self.options_prefix}options_left", False)
 
         if options_left:
             weakref.finalize(self, _warn_unused_options,


### PR DESCRIPTION
Fixes using `-prefix_options_left` for scoped warnings.