### PR TITLE
Convert PC Python objects into strings

### DIFF
--- a/petsctools/options.py
+++ b/petsctools/options.py
@@ -432,7 +432,10 @@ class OptionsManager:
         # Replace any Python objects in the parameters dict with appctx entries
         appmngr = AppContextManager()
         for key, value in parameters.items():
-            if not isinstance(value, _native_petsc_option_types):
+            # Convert Python PC objects into their string representation
+            if key.endswith("pc_python_type") and isinstance(value, type):
+                parameters[key] = f"{value.__module__}.{value.__name__}"
+            elif not isinstance(value, _native_petsc_option_types):
                 parameters[key] = appmngr.add(value)
         self.appmngr = appmngr
 

--- a/petsctools/options.py
+++ b/petsctools/options.py
@@ -433,7 +433,7 @@ class OptionsManager:
         appmngr = AppContextManager()
         for key, value in parameters.items():
             # Convert Python PC objects into their string representation
-            if key.endswith("pc_python_type") and isinstance(value, type):
+            if key.endswith("python_type") and isinstance(value, type):
                 parameters[key] = f"{value.__module__}.{value.__name__}"
             elif not isinstance(value, _native_petsc_option_types):
                 parameters[key] = appmngr.add(value)

--- a/tests/docs/test_appctx_docs.py
+++ b/tests/docs/test_appctx_docs.py
@@ -100,7 +100,7 @@ def test_appctx_docs():
             'ksp_converged_reason': None,
             'ksp_type': 'richardson',
             'pc_type': 'python',
-            'pc_python_type': f'{__name__}.DiffusionJacobiPC',
+            'pc_python_type': DiffusionJacobiPC,
             'djacobi_scale': 0.9,
             'djacobi_sigma': sigma_p,
         },

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -182,7 +182,8 @@ class JacobiTestPC:
 
 @pytest.mark.skipnopetsc4py
 @pytest.mark.parametrize("use_prefix", ["with_prefix", "without_prefix"])
-def test_appctx_context_manager(use_prefix):
+@pytest.mark.parametrize("use_pc_class", [False, True])
+def test_appctx_context_manager(use_prefix, use_pc_class):
     PETSc = petsctools.init()
     n = 4
     sizes = (n, n)
@@ -199,10 +200,14 @@ def test_appctx_context_manager(use_prefix):
     parameters = {
         'ksp_type': 'preonly',
         'pc_type': 'python',
-        'pc_python_type': f'{__name__}.JacobiTestPC',
         'jacobi_use_prefixed_appctx': use_prefix == "with_prefix",
         'jacobi_scale': diag,
     }
+    if use_pc_class:
+        parameters['pc_python_type'] = JacobiTestPC
+    else:
+        parameters['pc_python_type'] = f'{__name__}.JacobiTestPC'
+
     petsctools.set_from_options(
         ksp, parameters=parameters, options_prefix="myksp"
     )


### PR DESCRIPTION
Makes it much more pleasant to construct preconditioners.

It really is that easy.

(Tests and Firedrake PR to follow)